### PR TITLE
initial commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+obj-m := kbdh.o
+kbdh-y := kbd_handler.o ./src/keyp.o ./src/fs.o
+EXTRA_CFLAGS += -Werror -Wall -Wno-missing-braces -O2 -Wno-error=unused-function
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+install:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules_install
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean


### PR DESCRIPTION
Compiles with `-Werror` and `-Wall` since we want to take warnings seriously.
Make sure you built the sources first before using `modules_install`, that is because `modules_install` doesn't perform compilation (doesn't call `modules`)